### PR TITLE
Add ability to easily select all for multi-filter

### DIFF
--- a/client/app/services/query-result.js
+++ b/client/app/services/query-result.js
@@ -1,9 +1,12 @@
 import debug from 'debug';
 import moment from 'moment';
-import { uniq, contains, values, some, each, isArray, isNumber, isString } from 'underscore';
+import { uniq, contains, values, some, each, isArray, isNumber, isString, includes } from 'underscore';
 
 const logger = debug('redash:services:QueryResult');
 const filterTypes = ['filter', 'multi-filter', 'multiFilter'];
+
+const ALL_VALUES = '*';
+const NONE_VALUES = '-';
 
 function getColumnNameWithoutType(column) {
   let typeSplit;
@@ -208,6 +211,21 @@ function QueryResultService($resource, $timeout, $q) {
         this.filterFreeze = filterFreeze;
 
         if (filters) {
+          filters.forEach((filter) => {
+            if (filter.multiple && includes(filter.current, ALL_VALUES)) {
+              filter.current = filter.values.slice(1);
+            }
+
+            if (filter.current.length === (filter.values.length - 1)) {
+              filter.values[0] = NONE_VALUES;
+            }
+
+            if (filter.multiple && includes(filter.current, NONE_VALUES)) {
+              filter.current = [];
+              filter.values[0] = ALL_VALUES;
+            }
+          });
+
           this.filteredData = this.query_result.data.rows.filter(row =>
              filters.reduce((memo, filter) => {
                if (!isArray(filter.current)) {
@@ -376,6 +394,12 @@ function QueryResultService($resource, $timeout, $q) {
             }
           }
         });
+      });
+
+      filters.forEach((filter) => {
+        if (filter.multiple) {
+          filter.values.unshift(ALL_VALUES);
+        }
       });
 
       filters.forEach((filter) => {


### PR DESCRIPTION
The multi filter option is useful but lacking in an easy easy way to
select all values. I have added in a psudo option '*' that when selected
automatically fills out the mutli-select with all possible filters.

I have also added in a second psudo option '-' which becomes available
_if_ the multi-filter has all possible values selected.
This makes it easy to clear the multi-filter.